### PR TITLE
Fixed build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "start": "parcel --target site",
-    "build": "rimraf ./dist ./public && parcel build --no-cache",
+    "build": "rimraf ./dist ./public && parcel build --no-cache --target module --target umd --target styles --target types",
     "build-site": "rimraf ./public && parcel build --target site",
     "version": "npm run build",
     "postversion": "git push && git push --tags"


### PR DESCRIPTION
For whatever reason, `parcel build` errors when called with no arguments. We're now passing it each and every target explicitly.